### PR TITLE
build: use gradle-build-action to submit deps

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -7,12 +7,11 @@ on:
     branches: [ "main" ]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
       - name: Set up JDK 17
@@ -23,20 +22,7 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
+          dependency-graph: generate-and-summit
           arguments: build --scan
         env:
           GRADLE_TOS_AGREE: yes
-  
-  analyze:
-    runs-on: ubuntu-latest
-    permissions: # The Dependency Submission API requires write permission
-      contents: write
-    
-    steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v4
-      - name: Gradle Dependency Submission
-        uses: mikepenz/gradle-dependency-submission@v0.9.0
-        with:
-          include-build-environment: true
-          sub-module-mode: INDIVIDUAL

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Build with Gradle
         uses: gradle/gradle-build-action@v2
         with:
-          dependency-graph: generate-and-summit
+          dependency-graph: generate-and-submit
           arguments: build --scan
         env:
           GRADLE_TOS_AGREE: yes


### PR DESCRIPTION
Drop the use of a specific NodeJS action and just use the built in dependency submission mechanism of Gradle.