### PR TITLE
build: use chore type for renovate updates

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
-        "config:base"
+        ":semanticCommitTypeAll(chore)"
     ],
     "labels": ["dependency"],
     "reviewers": [],


### PR DESCRIPTION
This project has nearly no runtime dependencies.
Therefore, most dependency updates are test or build dependencies. So it makes sense to mark them as chore.